### PR TITLE
Add $(JANSSON_INCLUDES) to neoscrypt build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -132,4 +132,4 @@ neoscrypt/cuda_neoscrypt.o: neoscrypt/cuda_neoscrypt.cu
 	$(NVCC) -gencode=arch=compute_61,code=sm_61 -gencode=arch=compute_52,code=sm_52 -gencode=arch=compute_50,code=sm_50 -gencode=arch=compute_35,code=sm_35 -gencode=arch=compute_37,code=sm_37 @CUDA_INCLUDES@ -I. @CUDA_CFLAGS@ --ptxas-options="-v" -o $@ -c $<
 
 neoscrypt/cuda_neoscrypt_tpruvot.o: neoscrypt/cuda_neoscrypt_tpruvot.cu
-	$(NVCC) -gencode=arch=compute_61,code=sm_61 @CUDA_INCLUDES@ -I. @CUDA_CFLAGS@ --ptxas-options="-v" -o $@ -c $<
+	$(NVCC) -gencode=arch=compute_61,code=sm_61 @CUDA_INCLUDES@ -I. $(JANSSON_INCLUDES) @CUDA_CFLAGS@ --ptxas-options="-v" -o $@ -c $<


### PR DESCRIPTION
Fix to build cleanly on Linux with jansson compatibility