### PR TITLE
Read CPU Freq from scaling_cur_freq

### DIFF
--- a/sysinfos.cpp
+++ b/sysinfos.cpp
@@ -40,7 +40,7 @@ static double linux_cputemp(int core)
 }
 
 #define CPUFREQ_PATH \
- "/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_cur_freq"
+ "/sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq"
 static uint32_t linux_cpufreq(int core)
 {
 	FILE *fd = fopen(CPUFREQ_PATH, "r");


### PR DESCRIPTION
Propose changing this to scaling_cur_freq as by default cpuinfo_cur_freq is only readable by root user.

Running as non-root user, cpuinfo_cur_freq is not readable and will cause ccminer to segfault. It is probably not the best practice to chmod 444 cpuinfo_cur_freq or to run ccminer as root/sudo

Refer to the following for difference between cpuinfo_cur_freq and scaling_cur_feq:
https://www.kernel.org/doc/Documentation/cpu-freq/pcc-cpufreq.txt